### PR TITLE
feat: add the target scroll depth to the event object

### DIFF
--- a/src/lib/events/combinedTimeSpentAndScrollDepth.js
+++ b/src/lib/events/combinedTimeSpentAndScrollDepth.js
@@ -62,7 +62,10 @@ module.exports = function(settings, trigger) {
                 if (state.hasTriggered === false || settings.fireOnce === false) {
                   state.hasTriggered = true;
                   trigger({
-                    "subType": "scrollDepth"
+                    "subType": "scrollDepth",
+                    // set the targetScrollDepth in the event
+                    // so that it can be used with a Rule's conditions and actions
+                    "scrollDepth": targetScrollDepth
                   });
                 }
               }


### PR DESCRIPTION
This is so that the scroll depth can be used in the Rule's conditions and/or actions.

Closes #1 